### PR TITLE
Bv release 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Removed
-
 ## [1.0.2] - 2022-01-04
 
+### Removed
+
 - Drop Support for Ruby 2.6 or less
+
+### Refactory
+
 - Refactory CPF and CNPJ Validators to use new bra_documents's methods
+
+### Added
+
 - Add new validator to check if an attribute is a CPF or a CNPJ
 
 ## [1.0.1] - 2020-11-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Removed
 
+## [1.0.2] - 2022-01-04
+
 - Drop Support for Ruby 2.6 or less
 - Refactory CPF and CNPJ Validators to use new bra_documents's methods
 - Add new validator to check if an attribute is a CPF or a CNPJ

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bra_document_validation (1.0.1)
+    bra_document_validation (1.0.2)
       activemodel (>= 4.0)
       bra_documents (>= 1.0.2)
 

--- a/lib/bra_document_validation/version.rb
+++ b/lib/bra_document_validation/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module BraDocumentValidation
-  VERSION = '1.0.1'
+  VERSION = '1.0.2'
 end


### PR DESCRIPTION
## [1.0.2] - 2022-01-04

### Removed

- Drop Support for Ruby 2.6 or less

### Refactory

- Refactory CPF and CNPJ Validators to use new bra_documents's methods

### Added

- Add new validator to check if an attribute is a CPF or a CNPJ